### PR TITLE
This commit implements a fix for interactive elements that used `:hov…

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,29 @@
             width: 300px;
             height: 300px;
         }
+
+        /* --- Touch-based Animation Trigger --- */
+        .pillar-card.touch-hover {
+            transform: translateY(-5px) scale(1.02);
+            border-color: #c8a44d;
+            box-shadow: 0 0 20px rgba(200, 164, 77, 0.4);
+        }
+        .pillar-card.touch-hover::before {
+            width: 300px;
+            height: 300px;
+        }
+        .planetary-seal.touch-hover {
+             transform: scale(1.1);
+        }
+        .planetary-seal.touch-hover .seal-icon {
+            border-color: #c8a44d;
+            box-shadow: 0 0 15px rgba(200, 164, 77, 0.4);
+        }
+        .crystal-orb.touch-hover {
+            transform: translateY(-5px) scale(1.05);
+            border-color: #c8a44d;
+            box-shadow: 0 0 20px rgba(200, 164, 77, 0.3);
+        }
         
         /* --- Content Sections & Animations --- */
         .content-section { display: none; animation: fadeIn 0.8s ease-out; }

--- a/index.tsx
+++ b/index.tsx
@@ -479,6 +479,17 @@ function renderGrimoireEntries(entries) {
 
 
 // --- EVENT LISTENERS ---
+function triggerTouchAnimation(element) {
+    if (!element) return;
+    // Prevent re-triggering if animation is in progress
+    if (element.classList.contains('touch-hover')) return;
+
+    element.classList.add('touch-hover');
+    setTimeout(() => {
+        element.classList.remove('touch-hover');
+    }, 1000);
+}
+
 function setupEventListeners() {
     document.getElementById('close-modal-btn')?.addEventListener('click', () => hideModal(errorModal));
     document.getElementById('close-detail-modal')?.addEventListener('click', () => hideModal(detailModal));
@@ -531,7 +542,9 @@ function setupEventListeners() {
         
         const pillarCard = target.closest('.pillar-card');
         if (pillarCard instanceof HTMLElement && pillarCard.dataset.pillar) {
-            showPillarDetails(pillarCard.dataset.pillar);
+            triggerTouchAnimation(pillarCard);
+            const pillarId = pillarCard.dataset.pillar;
+            setTimeout(() => showPillarDetails(pillarId), 300);
             return;
         }
 
@@ -559,6 +572,7 @@ function setupEventListeners() {
 
         const crystalOrb = target.closest('.crystal-orb');
         if (crystalOrb instanceof HTMLElement && crystalOrb.dataset.crystalName) {
+            triggerTouchAnimation(crystalOrb);
             const name = crystalOrb.dataset.crystalName;
             let crystal = (cosmogramData.sun.name === name) ? cosmogramData.sun : cosmogramData.orbits.flatMap(o => o.crystals).find(c => c.name === name);
             if (crystal) showCrystalDetails(crystal);
@@ -567,6 +581,7 @@ function setupEventListeners() {
 
         const planetarySeal = target.closest('.planetary-seal');
         if (planetarySeal instanceof HTMLElement && planetarySeal.dataset.sealName) {
+            triggerTouchAnimation(planetarySeal);
             const seal = altarData.seals.find(s => s.name === planetarySeal.dataset.sealName);
             if(seal) showPlanetarySealDetails(seal);
             return;


### PR DESCRIPTION
…er` pseudo-classes for animations, which did not work on touch-based devices.

The solution involves two parts:
1.  A new set of CSS classes (`.touch-hover`) were added to `index.html`. These classes replicate the existing `:hover` styles (e.g., glowing borders, scaling) for elements like `.pillar-card`, `.crystal-orb`, and `.planetary-seal`.
2.  A JavaScript helper function, `triggerTouchAnimation`, was added to `index.tsx`. This function is called from the main event listener on a click/touch event. It applies the `.touch-hover` class to the element and removes it after a 1-second timeout, creating a "pulse" effect that provides visual feedback on touchscreens.